### PR TITLE
Updated conflicting doc describing unit of measurement of timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Debug Mode will output useful information about what's going on, including  the 
 
 
 ## Custom timeouts
-You can set the request timeout (in milliseconds):
+You can set the request timeout (in seconds):
 ```ruby
 # set the timeout as 1 second
 factual = Factual.new(key, secret, :timeout => 1)


### PR DESCRIPTION
Docs were a bit confusing at first describing how to set the timeout of my request.  After checking the ruby docs (http://ruby-doc.org/stdlib-2.1.1/libdoc/timeout/rdoc/Timeout.html) then I figured out which unit of measurement was correct.

Hoping to make this clearer with this PR.

Addresses issue:  https://github.com/Factual/factual-ruby-driver/issues/35